### PR TITLE
added description for video + fixed tiny typo

### DIFF
--- a/PublicWebsite/content/Resources/_index.md
+++ b/PublicWebsite/content/Resources/_index.md
@@ -13,7 +13,8 @@ draft: false
 #### Tutorials
 
 * https://youtu.be/E3Tx2DseLGE - <b><font color=red>Object Computing dapp tutorial</font></b>
-
+        
+	* Note (optional): checkout the `april-26-workshop` branch if you want to follow the example from the video on your local machine.
 	* [Contract basics (hello contact example)](https://youtu.be/E3Tx2DseLGE?t=29m) (29 minutes - 44 minutes)
 	* [Contract deeper dive (Addressbook contract example)](https://youtu.be/E3Tx2DseLGE?t=44m13s)  (44 minutes - 50 minutes)
 	* [Writing to tables (storage)](https://youtu.be/E3Tx2DseLGE?t=50m27s)  (50 minutes - 1 hr)

--- a/PublicWebsite/content/Resources/_index.md
+++ b/PublicWebsite/content/Resources/_index.md
@@ -26,7 +26,7 @@ draft: false
 * https://github.com/jafri/eos-debug
 
 #### Benchmarks / Performance
-* https://vimeo.com/266585781
+* https://vimeo.com/266585781 - Matt (block.one) demonstrates using the "txn_test_gen_plugin" plugin to generate 1000 transactions per seconds.
 
 #### Tools
 * https://tbfleming.github.io/cib/eos.html  - C++ -> WASM compiler
@@ -37,7 +37,7 @@ draft: false
 * http://jungle.cryptolions.io:9898/monitor/
 
 #### Launch 
-* https://eoscountdown.com/ - Check that your ETH address is registored
+* https://eoscountdown.com/ - Check that your ETH address is registered
 
 #### Security
 * https://medium.com/@bytemaster/debunking-claimed-vulnerability-in-eosio-smart-contract-system-9fa1ca2a6428


### PR DESCRIPTION
added description for a video link, fixed a typo, and also added the branch on which Kevin's video tutorial is based to allow people to setup their local box and follow along before starting the video (the branch is mentioned in the video but only at the very end). 