### PR TITLE
Add back lost API endpoints

### DIFF
--- a/PublicWebsite/content/Resources/apiendpoints/index.md
+++ b/PublicWebsite/content/Resources/apiendpoints/index.md
@@ -23,6 +23,9 @@ These are public API endpoints that can be used to vote / interact with the prod
 * `http://eos-api.worbli.io:80`
 * `https://eos-api.worbli.io:443`
 * `https://user-api.eoseoul.io/`
+* `https://api.eosuk.io:443`
+* `http://api1.eosdublin.io`
+* `http://api.eosvibes.io:80`
 
 #### Usage Note for cleos users
 


### PR DESCRIPTION
These were lost when https://github.com/BinaryFocus/eosdocs.io/pull/43 was merged.