### PR TITLE
Add Jungle testnet API endpoint

### DIFF
--- a/PublicWebsite/content/Resources/apiendpoints/_index.md
+++ b/PublicWebsite/content/Resources/apiendpoints/_index.md
@@ -65,4 +65,4 @@ To check if the endpoint you've selected will work for voting, run:
 If you get back a list of producers then you should be ok. 
 ### Testnet API Endpoints
 
-Coming Soon
+* `https://jungle.eosio.cr:443`


### PR DESCRIPTION
As a block producer candidate EOS Costa Rica is running a public API endpoint on the jungle testnet http://jungle.cryptolions.io/ available for community use.